### PR TITLE
Changed position of overlay to fixed

### DIFF
--- a/heyoffline.js
+++ b/heyoffline.js
@@ -80,7 +80,7 @@
       };
       this.defaultStyles = {
         overlay: {
-          position: 'absolute',
+          position: 'fixed',
           top: 0,
           left: 0,
           width: '100%',


### PR DESCRIPTION
The overlay was absolutely positioned. Hence if the user scrolled down the overlay did not stay put on top of the content.
